### PR TITLE
Fix typo in getting-started docs

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -45,7 +45,7 @@ func main() {
 ```
 
 ## API Reference
-Avalable at [https://pkg.go.dev/github.com/open-and-sustainable/alembica](https://pkg.go.dev/github.com/open-and-sustainable/alembica).
+Available at [https://pkg.go.dev/github.com/open-and-sustainable/alembica](https://pkg.go.dev/github.com/open-and-sustainable/alembica).
 
 ## Configuration
 `alembica` requires API keys to interact with LLM providers. API keys should be included within the JSON input data structures instead of environment variables or separate configuration files.


### PR DESCRIPTION
## Summary
- fix API docs reference typo in `getting-started.md`

## Testing
- `go test ./...` *(fails: Forbidden download)*

------
https://chatgpt.com/codex/tasks/task_e_6842cfc9c46c832cafc875471939802f