### PR TITLE
Improve ComputeCosts test assertions

### DIFF
--- a/pricing/quantification_test.go
+++ b/pricing/quantification_test.go
@@ -38,4 +38,41 @@ func TestComputeCosts(t *testing.T) {
 	if err = json.Unmarshal([]byte(resultJSON), &result); err != nil {
 		t.Errorf("Invalid JSON output: %v", err)
 	}
+	// Verify metadata section exists and has the correct schema version
+	metadata, ok := result["metadata"].(map[string]interface{})
+	if !ok {
+		t.Fatalf("metadata missing or invalid")
+	}
+	if metadata["schemaVersion"] != "v1" {
+		t.Errorf("expected schemaVersion v1, got %v", metadata["schemaVersion"])
+	}
+
+	// Ensure costs array is present and not empty
+	costs, ok := result["costs"].([]interface{})
+	if !ok {
+		t.Fatalf("costs missing or invalid")
+	}
+	if len(costs) == 0 {
+		t.Errorf("expected costs array to be non-empty")
+	}
+
+	// Optionally verify each cost entry contains expected keys
+	for i, c := range costs {
+		costMap, ok := c.(map[string]interface{})
+		if !ok {
+			t.Fatalf("cost entry %d has invalid type", i)
+		}
+		if _, ok := costMap["sequenceId"]; !ok {
+			t.Errorf("cost entry %d missing sequenceId", i)
+		}
+		if _, ok := costMap["provider"]; !ok {
+			t.Errorf("cost entry %d missing provider", i)
+		}
+		if _, ok := costMap["model"]; !ok {
+			t.Errorf("cost entry %d missing model", i)
+		}
+		if _, ok := costMap["cost"]; !ok {
+			t.Errorf("cost entry %d missing cost", i)
+		}
+	}
 }


### PR DESCRIPTION
## Summary
- extend pricing test to verify output structure of ComputeCosts

## Testing
- `go test ./...` *(fails: Forbidden to download toolchain)*

------
https://chatgpt.com/codex/tasks/task_e_6842cfe07cc8832cb5ea909d3d67f888