### PR TITLE
Fix issue 30 - pin macOS runner

### DIFF
--- a/.github/workflows/shared.yml
+++ b/.github/workflows/shared.yml
@@ -107,7 +107,9 @@ jobs:
 
   build-macos-arm64:
     name: Build macOS ARM64 Shared Library
-    runs-on: macos-latest
+    # Pin to macOS 14 to avoid unexpected updates when macos-latest migrates
+    # to macOS 15. See issue #30.
+    runs-on: macos-14
     permissions:
       contents: write  # Needed for uploading release assets
     steps:


### PR DESCRIPTION
## Summary
- pin the macOS ARM64 job to `macos-14`

## Testing
- `go test ./...` *(fails: missing API keys)*

------
https://chatgpt.com/codex/tasks/task_e_6878ce2ba0ec832cbd1959877821031f